### PR TITLE
Added put method to flight log update.

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -78,6 +78,7 @@ Rails.application.routes.draw do
   get 'api/flight-logs/ships' => 'flight_logs#list_ships'
   get 'api/flight-logs/:flight_log_id' => 'flight_logs#show'
   post 'api/flight-logs' => 'flight_logs#create'
+  put 'api/flight-logs' => 'flight_logs#update'
   patch 'api/flight-logs' => 'flight_logs#update'
   delete 'api/flight-logs/:flight_log_id' => 'flight_logs#delete'
 


### PR DESCRIPTION
HTTP client apparently does not have a patch method. It just has put. Put method added to routes for doing updates from the iOS app to flight logs. This will have to be done elsewhere for other things to work properly.