### PR TITLE
Fixed issue caused by null offender name

### DIFF
--- a/app/models/offender_report_offender.rb
+++ b/app/models/offender_report_offender.rb
@@ -1,5 +1,5 @@
 class OffenderReportOffender < ApplicationRecord
-  before_save { self.offender_name.downcase! }
+  before_save { self.offender_name.downcase! if self.offender_name }
 
   validates :offender_handle, presence: true, length: { maximum: 255 }, uniqueness: { case_sensitive: false }
   validates :offender_name, length: { maximum: 255 }


### PR DESCRIPTION
```
undefined method `downcase!' for nil:NilClass

/app/app/models/offender_report_offender.rb:2:in `block in ' 
/app/vendor/bundle/ruby/2.6.0/gems/activesupport-5.1.6/lib/active_support/callbacks.rb:413:in `instance_exec' 
/app/vendor/bundle/ruby/2.6.0/gems/activesupport-5.1.6/lib/active_support/callbacks.rb:413:in `block in make_lambda' 
/app/vendor/bundle/ruby/2.6.0/gems/activesupport-5.1.6/lib/active_support/callbacks.rb:197:in `block (2 levels) in halting' 

```
Fixed issue caused by null offender name. There was a change made which allowed for offender names to be null (since most info is by handle anyways) and this resulted in an exception when the object is created.