### PR TITLE
Removed .rbenv folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,7 @@
 
 # rbenv
 .rbenv
-/.rbenv
+/.rbenv/*
 
 # Ignore bundler config.
 /.bundle


### PR DESCRIPTION
Removed .rbenv folder. This was causing build and deployment issues. It ended up there after it was added while developing on WSL.