### PR TITLE
Improvements to handling of Discord identity

### DIFF
--- a/app/models/discord_identity.rb
+++ b/app/models/discord_identity.rb
@@ -1,4 +1,47 @@
+require 'httparty'
+
 class DiscordIdentity < ApplicationRecord
   before_create { self.id = SecureRandom.uuid if self.id == nil && ENV["RAILS_ENV"] != 'production' }
   belongs_to :user
+
+  # validations
+  validates :user_id, presence: true
+  validates :discord_username, presence: true
+  validates :discord_id, presence: true
+  validates :refresh_token, presence: true
+
+  # Retrieve an access token for the Discord Identity
+  def access_token
+    # client info
+    client_id = '630786822863061014'
+    client_secret = ENV["DISCORD_BOT_CLIENT_SECRET"]
+
+    # get an access token w/ refresh_token
+    body_string = "client_id=#{client_id}&client_secret=#{client_secret}&grant_type=refresh_token&refresh_token=#{dit.refresh_token}&redirect_uri=https%3A%2F%2Fmy.bendrocorp.com%2Fdiscord_callback&scope=guilds.join+email+identify" if ENV["RAILS_ENV"] != nil && ENV["RAILS_ENV"] == 'production'
+    body_string ||= "client_id=#{client_id}&client_secret=#{client_secret}&grant_type=refresh_token&refresh_token=#{dit.refresh_token}&redirect_uri=http%3A%2F%2Flocalhost%3A4200%2Fdiscord_callback&scope=guilds.join+email+identify"
+
+    response = HTTParty.post('https://discordapp.com/api/v6/oauth2/token', {
+      body: body_string,
+      headers: {
+        'Content-Type' => 'application/x-www-form-urlencoded',
+        'charset' => 'utf-8'
+      }
+    })
+
+    if response.code == 200
+      # update the refresh_token - since Discord invalidates the refresh_token after its used 😁
+      dit.refresh_token = response['refresh_token']
+      
+      if dit.save
+        access_token = response['access_token']
+
+        # return the access token
+        access_token
+      else
+        raise "Could not save back refresh_token to identity #{dit.id} because: #{dit.errors.full_messages.to_sentence}"
+      end
+    else
+      raise "Could not retrieve refresh_token for dit: #{dit.id}. body_string: |#{body_string}| Response: #{response.inspect}"
+    end
+  end
 end

--- a/app/workers/dormant_discord_completion_worker.rb
+++ b/app/workers/dormant_discord_completion_worker.rb
@@ -4,25 +4,8 @@ class DormantDiscordCompletionWorker
   def perform(*args)
     # if a request is still hanging out the bot may have missed it. So just repeat the event
     DiscordIdentity.where(joined: false).each do |dit|
-      client_id = '630786822863061014'
-      client_secret = ENV["DISCORD_BOT_CLIENT_SECRET"]
-      # get an access token
-      body_string = "client_id=#{client_id}&client_secret=#{client_secret}&grant_type=refresh_token&refresh_token=#{dit.refresh_token}&redirect_uri=https%3A%2F%2Fmy.bendrocorp.com%2Fdiscord_callback&scope=guilds.join+email+identify" if ENV["RAILS_ENV"] != nil && ENV["RAILS_ENV"] == 'production'
-      body_string ||= "client_id=#{client_id}&client_secret=#{client_secret}&grant_type=refresh_token&refresh_token=#{dit.refresh_token}&redirect_uri=http%3A%2F%2Flocalhost%3A4200%2Fdiscord_callback&scope=guilds.join+email+identify"
-
-      response = HTTParty.post('https://discordapp.com/api/v6/oauth2/token', {
-        body: body_string,
-        headers: {
-          'Content-Type' => 'application/x-www-form-urlencoded',
-          'charset' => 'utf-8'
-        }
-      })
-
-      if response.code == 200
-        EventStreamWorker.perform_async('discord-join', { access_token: response['access_token'], nickname: discord_identity.user.main_character.full_name, identity: discord_identity.as_json })
-      else
-        raise "Could not retrieve refresh_token for dit: #{dit.id}. body_string: |#{body_string}| Response: #{response.inspect}"
-      end
+      # repeat/send the join event for that Discord identity so the bot picks it up again
+      EventStreamWorker.perform_async('discord-join', { access_token: dit.access_token, nickname: discord_identity.user.main_character.full_name, identity: discord_identity.as_json })
     end
   end
 end


### PR DESCRIPTION
Mainly in the area of how the system handles **refresh_tokens** since it appears that Discord invalidates refresh tokens once they are used to fetch a new access token.